### PR TITLE
Fix marketplace plugin source path validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "imessage",
-      "source": ".",
+      "source": "./",
       "description": "iMessage integration for Claude Code — read, send, and auto-reply to iMessages on macOS"
     }
   ]


### PR DESCRIPTION
## Summary
- Plugin source field in marketplace.json must start with `./` per Claude Code schema
- Changed `"source": "."` to `"source": "./"` to pass validation
- Fixes: `/plugin marketplace add felipe/iMessage-Claude-Bridge` failing with `plugins.0.source: Invalid input`

## Test plan
- [ ] Run `/plugin marketplace add felipe/iMessage-Claude-Bridge` on a clean machine