### PR TITLE
Fix plugin manifest repository field type

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,10 +5,7 @@
   "author": {
     "name": "Felipe Oduardo Sierra"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/felipe/iMessage-Claude-Bridge"
-  },
+  "repository": "https://github.com/felipe/iMessage-Claude-Bridge",
   "keywords": [
     "imessage",
     "messages",


### PR DESCRIPTION
## Summary
- Plugin schema expects `repository` as a plain string URL, not a `{type, url}` object
- Fixes: `repository: Invalid input: expected string, received object` during install

## Test plan
- [ ] `/plugin install imessage@imessage-claude-bridge` succeeds after merge