### PR TITLE
Fix daemon PROJECT_ROOT path resolution

### DIFF
--- a/skills/imessage/daemon/imessage-auto-reply-daemon.sh
+++ b/skills/imessage/daemon/imessage-auto-reply-daemon.sh
@@ -14,7 +14,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TMP_DIR="${IMESSAGE_TMP_DIR:-$HOME/tmp/imessage}"
 PROCESSED_LOG="$TMP_DIR/processed_imessages.log"
 CONVERSATION_ID_FILE="$TMP_DIR/imessage_claude_conversation_id.txt"


### PR DESCRIPTION
## Summary

- The daemon script at `skills/imessage/daemon/` traverses up 2 levels (`../..`) to compute `PROJECT_ROOT`, which resolves to `skills/` instead of the plugin root directory
- This causes `IMESSAGE_SKILL` to become `skills/skills/imessage/` — a nonexistent path — making the daemon crash immediately on the first polling loop iteration due to `set -e`
- Fixed by traversing up 3 levels (`../../..`) from the daemon directory to correctly reach the plugin root

## Test plan

- [ ] Start the daemon with `source ~/.claude-imessage.env && imessage-auto-reply-daemon.sh`
- [ ] Verify it stays running and polls for messages without crashing
- [ ] Send a test message and confirm the agent session launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)