### PR TITLE
Add FDA launcher for launchd daemon support

### DIFF
--- a/skills/imessage/daemon/launcher.swift
+++ b/skills/imessage/daemon/launcher.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// joi-launcher: FDA-granted process wrapper for launchd agents
+// Add this binary to System Settings > Privacy > Full Disk Access
+// It spawns the given command as a child process (inheriting FDA)
+// and waits for it to exit, forwarding the exit code.
+//
+// Build: swiftc -O -o joi-launcher joi-launcher.swift
+
+guard CommandLine.arguments.count > 1 else {
+    fputs("Usage: joi-launcher <command> [args...]\n", stderr)
+    exit(1)
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+let process = Process()
+process.executableURL = URL(fileURLWithPath: "/bin/bash")
+process.arguments = args
+process.environment = ProcessInfo.processInfo.environment
+
+do {
+    try process.run()
+    process.waitUntilExit()
+    exit(process.terminationStatus)
+} catch {
+    fputs("joi-launcher: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- Adds `launcher.swift` to `skills/imessage/daemon/` — a Swift wrapper that spawns child processes with inherited Full Disk Access
- Required for the iMessage daemon to read `chat.db` when running as a LaunchAgent (launchd doesn't inherit Terminal's TCC grants)
- Build: `swiftc -O -o launcher launcher.swift`, then add the binary to System Settings > Privacy > Full Disk Access

## Test plan
- [ ] Compile with `swiftc -O -o launcher launcher.swift`
- [ ] Add compiled binary to Full Disk Access in System Settings
- [ ] Use as LaunchAgent ProgramArguments[0] wrapping the daemon script
- [ ] Verify daemon can read chat.db and respond to messages