### PR TITLE
Fix daemon log leaking into message collection

### DIFF
--- a/skills/imessage/daemon/imessage-auto-reply-daemon.sh
+++ b/skills/imessage/daemon/imessage-auto-reply-daemon.sh
@@ -184,7 +184,7 @@ collect_messages() {
             elif [ -n "$guid" ]; then
                 thread_id="$guid"
             fi
-            log "New message (thread: $thread_id): \"$text\""
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] New message (thread: $thread_id): \"$text\"" >> "$LOG_FILE"
             mark_as_processed "$msg_id"
             echo "${thread_id}|${chat:-$CONTACT_PHONE}|${msg_is_reply}|${text}"
         fi


### PR DESCRIPTION
## Summary

- `log()` writes to stdout, which was captured by `collect_messages()` and treated as message entries
- This caused garbled thread IDs and `integer expression expected` errors
- Fix: write directly to log file inside `collect_messages` instead of using `log()`

Found during live daemon testing after #22.