### PR TITLE
Add scoped file logic tests and macOS smoke test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,12 @@ macos-mcp send message|file|chat [args...]         # AppleScript via osascript
 macos-mcp typing <contact> start|stop|keepalive    # Typing indicator
 ```
 
-Build: `make` — Restart service after build: `make install`
+Build: `make build` (compile-only) or `make` (signed) — Restart service after build: `make install`
+
+Testing:
+- `make test-logic` — SwiftPM logic tests for allowlisted path + markdown transforms
+- `make test-logic-docker` — same logic tests in a Docker Swift image
+- `make test-build` — macOS-only compile + MCP smoke test for `scoped_read` / `scoped_write`
 
 ## MCP Tools (exposed via `serve`)
 
@@ -91,13 +96,23 @@ Build: `make` — Restart service after build: `make install`
 
 Vault root: `OBSIDIAN_VAULT_PATH` env var or `~/Library/Mobile Documents/com~apple~CloudDocs/Obsidian`
 
+### Allowlisted Files
+- `scoped_read` — read a UTF-8 text file from an allowlisted path
+- `scoped_write` — write under an allowlisted path
+  - `upsert` — create/overwrite a whole file
+  - `append-section` — append a new anchored `##` section
+  - `supersede` — replace an anchored section and archive the old body under `## Superseded`
+
+Allowed paths: `ALLOWED_PATHS_JSON` env var mapping `path_name` → absolute path
+Audit log: `ALLOWED_PATHS_AUDIT_LOG_PATH` env var or `~/.local/share/work-work/logs/allowed-paths-audit.log`
+
 ## Connecting an AI Agent
 
 Any MCP-compatible agent can connect to the serve endpoint:
 
 1. Point the agent's MCP client at `http://<mac-ip>:9200/mcp`
 2. Set up a webhook route for inbound messages (the poller POSTs with HMAC-SHA256)
-3. The agent gets all MCP tools (send, read, calendar, vault) automatically
+3. The agent gets all MCP tools (send, read, calendar, vault, scoped files) automatically
 4. Optional: set `--mcp-secret` for bearer token auth on the MCP endpoint
 
 ## Logging
@@ -110,7 +125,7 @@ Any MCP-compatible agent can connect to the serve endpoint:
 {"ts":"...","level":"info","component":"poller","msg":"Heartbeat","watermark":4866,"pending":0}
 ```
 
-Components: `server`, `mcp`, `poller`, `typing`, `webhook`, `vault`
+Components: `server`, `mcp`, `poller`, `typing`, `webhook`, `vault`, `files`
 
 Filter errors: `tail -f <log> | jq 'select(.level == "error")'`
 
@@ -139,6 +154,8 @@ Managed via: `make install` (build + restart) or `make restart`
 
 - **Binary**: `./macos-mcp` (build with `make`)
 - **Sources**: `Sources/*.swift`
+- **Logic tests**: `Tests/ScopedFilesCoreTests/`
+- **Smoke test**: `scripts/smoke-scoped-files.sh`
 - **Messages DB**: `~/Library/Messages/chat.db`
 - **Service logs**: `~/.local/share/work-work/logs/launchd-macos-mcp-serve.err.log`
 - **Watermark**: `~/tmp/imessage/watermark`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BINARY = macos-mcp
+UNSIGNED = .build/macos-mcp-unsigned
 STAGING = .build/macos-mcp
 INSTALLED = $(HOME)/.local/bin/macos-mcp
 SOURCES = $(wildcard Sources/*.swift)
@@ -8,18 +9,37 @@ SWIFTFLAGS = -O
 
 PLIST = $(HOME)/Library/LaunchAgents/com.macos-mcp.serve.plist
 
-.PHONY: all clean restart install deploy
+.PHONY: all build clean restart install deploy test-logic test-logic-docker test-build
 
-# Build to staging — does NOT touch the installed binary or invalidate FDA
+# Compile-only build for local/macOS smoke tests and CI checks
+build: $(UNSIGNED)
+
+# Signed build used for deploys and local installation
 all: $(STAGING)
 
-$(STAGING): $(SOURCES)
+$(UNSIGNED): $(SOURCES)
 	@mkdir -p .build
 	swiftc $(SWIFTFLAGS) -target arm64-apple-macosx13.0 $(FRAMEWORKS) $(LIBS) $(SOURCES) -o .build/$(BINARY)-arm64
 	swiftc $(SWIFTFLAGS) -target x86_64-apple-macosx13.0 $(FRAMEWORKS) $(LIBS) $(SOURCES) -o .build/$(BINARY)-x86_64
-	lipo -create .build/$(BINARY)-arm64 .build/$(BINARY)-x86_64 -output $(STAGING)
+	lipo -create .build/$(BINARY)-arm64 .build/$(BINARY)-x86_64 -output $(UNSIGNED)
 	rm -f .build/$(BINARY)-arm64 .build/$(BINARY)-x86_64
+
+$(STAGING): $(UNSIGNED)
+	cp $(UNSIGNED) $(STAGING)
 	codesign --force --sign "macos-mcp-dev" --identifier "com.felipe.macos-mcp" $(STAGING)
+
+# Pure logic tests — intended to run in Linux containers or any host with SwiftPM
+# Requires swift/swiftc to be available in the current environment.
+test-logic:
+	swift test
+
+# Convenience target for running logic tests in Docker.
+test-logic-docker:
+	docker run --rm -v "$$(pwd)":/src -w /src swift:6.0-jammy swift test
+
+# macOS-only compile + smoke test path for the scoped file MCP tools.
+test-build: build
+	./scripts/smoke-scoped-files.sh $(UNSIGNED)
 
 # Deploy: stop service, copy signed binary, restart
 deploy: $(STAGING)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "macos-mcp-logic-tests",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "ScopedFilesCore", targets: ["ScopedFilesCore"]),
+    ],
+    targets: [
+        .target(
+            name: "ScopedFilesCore",
+            path: "Sources",
+            sources: ["ScopedFilesCore.swift"]
+        ),
+        .testTarget(
+            name: "ScopedFilesCoreTests",
+            dependencies: ["ScopedFilesCore"],
+            path: "Tests/ScopedFilesCoreTests"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,29 @@ macOS system services for AI tools. Single Swift binary — runs as a CLI, MCP s
 ## Install
 
 ```bash
-make           # Build (requires Xcode CLT)
+make build     # Compile-only build (unsigned)
+make           # Signed build (requires Xcode CLT + signing cert)
 make install   # Build + restart launchd service
 ```
 
 Grant Full Disk Access to the `macos-mcp` binary in System Settings > Privacy & Security.
 
+## Testing
+
+This repo now splits tests into two layers:
+
+```bash
+make test-logic         # SwiftPM logic tests (Linux or macOS, requires swift)
+make test-logic-docker  # same logic tests in a Docker Swift image
+make test-build         # macOS-only compile + MCP smoke test for scoped_read/scoped_write
+```
+
+- Logic tests cover pure allowlisted-path and markdown-write behavior in `ScopedFilesCore.swift`
+- Build tests compile the binary on macOS and exercise the real MCP server via `scripts/smoke-scoped-files.sh`
+
 ## MCP Server
 
-Exposes iMessage, Calendar, file transfer, and Obsidian vault tools over the [MCP protocol](https://modelcontextprotocol.io) (Streamable HTTP transport). Remote AI agents connect to it to interact with macOS services.
+Exposes iMessage, Calendar, file transfer, Obsidian vault, and allowlisted file tools over the [MCP protocol](https://modelcontextprotocol.io) (Streamable HTTP transport). Remote AI agents connect to it to interact with macOS services.
 
 ```bash
 # Run MCP server with iMessage poller
@@ -34,6 +48,14 @@ When `--webhook-url` is provided, the server also polls `chat.db` for inbound me
 **Files**: `download_file` (URL → local path), `send_file` (local path → iMessage)
 
 **Obsidian Vault**: `vault_read`, `vault_write`, `vault_list`, `vault_search`
+
+**Allowlisted Files**: `scoped_read`, `scoped_write` — read/write under configured named paths using `path_name` + relative `path`; `scoped_write` supports `upsert`, `append-section`, and `supersede`
+
+Configure allowlisted paths with `ALLOWED_PATHS_JSON`, for example:
+
+```bash
+export ALLOWED_PATHS_JSON='{"notes":"/Users/agent/Documents/Notes","ops":"/Users/agent/Documents/Ops"}'
+```
 
 ## CLI Usage
 
@@ -97,7 +119,8 @@ tail -f ~/.local/share/work-work/logs/launchd-macos-mcp-serve.err.log | jq 'sele
 ```
 Sources/
   main.swift           # CLI router
-  Serve.swift          # MCP server + poller + typing + vault tools
+  Serve.swift          # MCP server + poller + typing + vault/scoped-file tools
+  ScopedFilesCore.swift# Allowlisted path logic + markdown transforms + audit writes
   Shared.swift         # JSON output, process runner with timeouts
   Messages.swift       # SQLite message queries
   Send.swift           # AppleScript wrappers (send, typing)
@@ -105,7 +128,12 @@ Sources/
   Attachments.swift    # Attachment processing + HEIC conversion
   ICloud.swift         # iCloud Drive file sync
   Launch.swift         # FDA process wrapper
-Makefile               # Build, install (build + restart), clean
+Tests/
+  ScopedFilesCoreTests/# Linux/macOS logic tests for allowlisted path behavior
+scripts/
+  smoke-scoped-files.sh# macOS MCP smoke test for scoped_read/scoped_write
+Package.swift          # SwiftPM manifest for logic tests
+Makefile               # Build, install, and test targets
 skills/
   imessage/
     daemon/            # Legacy auto-reply daemon (replaced by serve mode)

--- a/Sources/ScopedFilesCore.swift
+++ b/Sources/ScopedFilesCore.swift
@@ -1,0 +1,634 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+#if canImport(CommonCrypto)
+import CommonCrypto
+#endif
+
+struct ScopedFilesError: Error {
+    let message: String
+    let details: [String: Any]
+
+    init(_ message: String, details: [String: Any] = [:]) {
+        self.message = message
+        self.details = details
+    }
+
+    func jsonObject() -> [String: Any] {
+        var object = details
+        object["error"] = message
+        return object
+    }
+}
+
+struct ScopedReadResult {
+    let pathName: String
+    let path: String
+    let absolutePath: String
+    let content: String
+
+    func jsonObject() -> [String: Any] {
+        [
+            "path_name": pathName,
+            "path": path,
+            "absolute_path": absolutePath,
+            "content": content,
+        ]
+    }
+}
+
+struct ScopedWriteRequest {
+    let pathName: String
+    let path: String
+    let content: String
+    let mode: String
+    let sectionAnchor: String?
+    let sectionHeading: String?
+    let operationId: String?
+    let actor: String?
+    let metadata: Any?
+}
+
+struct ScopedWriteResult {
+    let pathName: String
+    let writtenPath: String
+    let absolutePath: String
+    let sha256: String
+    let timestamp: String
+
+    func jsonObject() -> [String: Any] {
+        [
+            "path_name": pathName,
+            "written_path": writtenPath,
+            "absolute_path": absolutePath,
+            "sha256": sha256,
+            "timestamp": timestamp,
+        ]
+    }
+}
+
+enum ScopedWriteMode: String {
+    case upsert = "upsert"
+    case appendSection = "append-section"
+    case supersede = "supersede"
+}
+
+func serializeJSONObject(_ object: Any) -> String {
+    guard JSONSerialization.isValidJSONObject(object),
+          let data = try? JSONSerialization.data(withJSONObject: object),
+          let json = String(data: data, encoding: .utf8) else {
+        return "{\"error\":\"Serialization failed\"}"
+    }
+    return json
+}
+
+func loadAllowedPaths(from environment: [String: String]) -> [String: String] {
+    guard let raw = environment["ALLOWED_PATHS_JSON"], let data = raw.data(using: .utf8) else {
+        return [:]
+    }
+    guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return [:]
+    }
+
+    var paths: [String: String] = [:]
+    for (name, value) in object {
+        guard let path = value as? String else { continue }
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedName.isEmpty {
+            paths[trimmedName] = path
+        }
+    }
+    return paths
+}
+
+/// Resolve a relative path against a root and verify it doesn't escape.
+/// Existing path components have symlinks resolved so symlinks inside the
+/// allowed root can be followed without allowing escapes outside the root.
+func resolveScopedPath(root: String, relative: String) -> String? {
+    guard !relative.isEmpty, !relative.hasPrefix("/") else { return nil }
+
+    let fm = FileManager.default
+    let expandedRoot = (root as NSString).expandingTildeInPath
+    let resolvedRoot = URL(fileURLWithPath: expandedRoot).resolvingSymlinksInPath().standardizedFileURL.path
+    let components = (relative as NSString).pathComponents.filter {
+        !$0.isEmpty && $0 != "/" && $0 != "."
+    }
+
+    if components.contains("..") { return nil }
+
+    var currentPath = resolvedRoot
+    for component in components {
+        let nextPath = (currentPath as NSString).appendingPathComponent(component)
+        let resolvedNext: String
+        if fm.fileExists(atPath: nextPath) {
+            resolvedNext = URL(fileURLWithPath: nextPath).resolvingSymlinksInPath().standardizedFileURL.path
+        } else {
+            resolvedNext = URL(fileURLWithPath: nextPath).standardizedFileURL.path
+        }
+
+        guard resolvedNext == resolvedRoot || resolvedNext.hasPrefix(resolvedRoot + "/") else {
+            return nil
+        }
+        currentPath = resolvedNext
+    }
+
+    return currentPath
+}
+
+private struct ManagedMarkdownSectionMatch {
+    let range: NSRange
+    let title: String
+    let block: String
+}
+
+private func trimBoundaryNewlines(_ string: String) -> String {
+    var trimmed = string
+    while trimmed.hasPrefix("\n") || trimmed.hasPrefix("\r") { trimmed.removeFirst() }
+    while trimmed.hasSuffix("\n") || trimmed.hasSuffix("\r") { trimmed.removeLast() }
+    return trimmed
+}
+
+private func humanizeSectionAnchor(_ anchor: String) -> String {
+    let words = anchor
+        .replacingOccurrences(of: "-", with: " ")
+        .replacingOccurrences(of: "_", with: " ")
+        .split(whereSeparator: { $0.isWhitespace })
+    guard !words.isEmpty else { return anchor }
+    return words.map { word in
+        let lower = word.lowercased()
+        return String(lower.prefix(1)).uppercased() + String(lower.dropFirst())
+    }.joined(separator: " ")
+}
+
+private func slugifyHeading(_ heading: String) -> String {
+    heading
+        .lowercased()
+        .components(separatedBy: CharacterSet.alphanumerics.inverted)
+        .filter { !$0.isEmpty }
+        .joined(separator: "-")
+}
+
+private func findManagedMarkdownSection(in content: String, anchor: String) -> ManagedMarkdownSectionMatch? {
+    let nsContent = content as NSString
+    let regex = try! NSRegularExpression(pattern: #"(?m)^##[ \t]+(.+?)\s*$"#)
+    let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
+    let normalizedAnchor = anchor.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let marker = "<!-- macos-mcp:section_anchor=\(normalizedAnchor) -->"
+
+    for (index, match) in matches.enumerated() {
+        let start = match.range.location
+        let end = index + 1 < matches.count ? matches[index + 1].range.location : nsContent.length
+        let range = NSRange(location: start, length: end - start)
+        let block = nsContent.substring(with: range)
+        let title = nsContent.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if block.contains(marker) || slugifyHeading(title) == normalizedAnchor {
+            return ManagedMarkdownSectionMatch(range: range, title: title, block: block)
+        }
+    }
+
+    return nil
+}
+
+private func findMarkdownSectionByTitle(in content: String, title: String) -> ManagedMarkdownSectionMatch? {
+    let nsContent = content as NSString
+    let regex = try! NSRegularExpression(pattern: #"(?m)^##[ \t]+(.+?)\s*$"#)
+    let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
+    let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+    for (index, match) in matches.enumerated() {
+        let start = match.range.location
+        let end = index + 1 < matches.count ? matches[index + 1].range.location : nsContent.length
+        let range = NSRange(location: start, length: end - start)
+        let headingTitle = nsContent.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+        if headingTitle.lowercased() == normalizedTitle {
+            return ManagedMarkdownSectionMatch(range: range, title: headingTitle, block: nsContent.substring(with: range))
+        }
+    }
+
+    return nil
+}
+
+private func isManagedMarkdownMetaComment(_ line: String) -> Bool {
+    line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("<!-- macos-mcp:")
+}
+
+private func managedMarkdownSectionBody(_ block: String) -> String {
+    var lines = block.components(separatedBy: .newlines)
+
+    if let first = lines.first,
+       first.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("## ") {
+        lines.removeFirst()
+    }
+
+    while let first = lines.first,
+          first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        lines.removeFirst()
+    }
+
+    while let first = lines.first, isManagedMarkdownMetaComment(first) {
+        lines.removeFirst()
+        while let next = lines.first,
+              next.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.removeFirst()
+        }
+    }
+
+    return trimBoundaryNewlines(lines.joined(separator: "\n"))
+}
+
+private func sanitizeManagedMarkdownCommentValue(_ value: String) -> String {
+    value.replacingOccurrences(of: "--", with: "—").replacingOccurrences(of: ">", with: "›")
+}
+
+private func renderManagedMarkdownSection(anchor: String, heading: String, body: String) -> String {
+    let normalizedAnchor = anchor.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let normalizedBody = trimBoundaryNewlines(body)
+    var lines = ["## \(heading)", "<!-- macos-mcp:section_anchor=\(normalizedAnchor) -->"]
+
+    if !normalizedBody.isEmpty {
+        lines.append("")
+        lines.append(normalizedBody)
+    }
+
+    return lines.joined(separator: "\n") + "\n"
+}
+
+private func renderSupersededEntry(
+    title: String,
+    anchor: String,
+    body: String,
+    operationId: String?,
+    actor: String?,
+    timestamp: String
+) -> String {
+    let normalizedAnchor = anchor.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let normalizedBody = trimBoundaryNewlines(body)
+    var lines = [
+        "### \(title)",
+        "<!-- macos-mcp:superseded_from=\(normalizedAnchor) -->",
+        "<!-- macos-mcp:superseded_at=\(sanitizeManagedMarkdownCommentValue(timestamp)) -->",
+    ]
+
+    if let operationId = operationId, !operationId.isEmpty {
+        lines.append("<!-- macos-mcp:operation_id=\(sanitizeManagedMarkdownCommentValue(operationId)) -->")
+    }
+    if let actor = actor, !actor.isEmpty {
+        lines.append("<!-- macos-mcp:actor=\(sanitizeManagedMarkdownCommentValue(actor)) -->")
+    }
+    if !normalizedBody.isEmpty {
+        lines.append("")
+        lines.append(normalizedBody)
+    }
+
+    return lines.joined(separator: "\n") + "\n"
+}
+
+private func appendMarkdownBlock(_ existing: String, block: String) -> String {
+    let trimmedExisting = existing.trimmingCharacters(in: CharacterSet(charactersIn: "\n\r"))
+    if trimmedExisting.isEmpty { return block }
+    return trimmedExisting + "\n\n" + block
+}
+
+private func upsertSupersededSection(content: String, entry: String) -> String {
+    if let superseded = findMarkdownSectionByTitle(in: content, title: "Superseded") {
+        let updatedBlock = appendMarkdownBlock(superseded.block, block: entry)
+        return (content as NSString).replacingCharacters(in: superseded.range, with: updatedBlock)
+    }
+
+    let newSupersededSection = "## Superseded\n\n" + entry
+    return appendMarkdownBlock(content, block: newSupersededSection)
+}
+
+private func rotateRight(_ value: UInt32, by amount: UInt32) -> UInt32 {
+    (value >> amount) | (value << (32 - amount))
+}
+
+func sha256Hex(_ data: Data) -> String {
+    #if canImport(CryptoKit)
+    let digest = SHA256.hash(data: data)
+    return digest.map { String(format: "%02x", $0) }.joined()
+    #elseif canImport(CommonCrypto)
+    var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    data.withUnsafeBytes { bytes in
+        _ = CC_SHA256(bytes.baseAddress, CC_LONG(data.count), &digest)
+    }
+    return digest.map { String(format: "%02x", $0) }.joined()
+    #else
+    let k: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ]
+
+    var h: [UInt32] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]
+
+    var message = Array(data)
+    let bitLength = UInt64(message.count) * 8
+    message.append(0x80)
+    while (message.count % 64) != 56 {
+        message.append(0)
+    }
+    message.append(contentsOf: withUnsafeBytes(of: bitLength.bigEndian, Array.init))
+
+    for chunkStart in stride(from: 0, to: message.count, by: 64) {
+        var w = [UInt32](repeating: 0, count: 64)
+
+        for i in 0..<16 {
+            let j = chunkStart + (i * 4)
+            w[i] = (UInt32(message[j]) << 24)
+                | (UInt32(message[j + 1]) << 16)
+                | (UInt32(message[j + 2]) << 8)
+                | UInt32(message[j + 3])
+        }
+
+        for i in 16..<64 {
+            let s0 = rotateRight(w[i - 15], by: 7) ^ rotateRight(w[i - 15], by: 18) ^ (w[i - 15] >> 3)
+            let s1 = rotateRight(w[i - 2], by: 17) ^ rotateRight(w[i - 2], by: 19) ^ (w[i - 2] >> 10)
+            w[i] = w[i - 16] &+ s0 &+ w[i - 7] &+ s1
+        }
+
+        var a = h[0]
+        var b = h[1]
+        var c = h[2]
+        var d = h[3]
+        var e = h[4]
+        var f = h[5]
+        var g = h[6]
+        var hh = h[7]
+
+        for i in 0..<64 {
+            let s1 = rotateRight(e, by: 6) ^ rotateRight(e, by: 11) ^ rotateRight(e, by: 25)
+            let ch = (e & f) ^ ((~e) & g)
+            let temp1 = hh &+ s1 &+ ch &+ k[i] &+ w[i]
+            let s0 = rotateRight(a, by: 2) ^ rotateRight(a, by: 13) ^ rotateRight(a, by: 22)
+            let maj = (a & b) ^ (a & c) ^ (b & c)
+            let temp2 = s0 &+ maj
+
+            hh = g
+            g = f
+            f = e
+            e = d &+ temp1
+            d = c
+            c = b
+            b = a
+            a = temp1 &+ temp2
+        }
+
+        h[0] = h[0] &+ a
+        h[1] = h[1] &+ b
+        h[2] = h[2] &+ c
+        h[3] = h[3] &+ d
+        h[4] = h[4] &+ e
+        h[5] = h[5] &+ f
+        h[6] = h[6] &+ g
+        h[7] = h[7] &+ hh
+    }
+
+    return h.map { String(format: "%08x", $0) }.joined()
+    #endif
+}
+
+private func rotateFileIfNeeded(at path: String, maxBytes: UInt64 = 5_000_000, keep: Int = 5) throws {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: path) else { return }
+    let attrs = try fm.attributesOfItem(atPath: path)
+    let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+    guard size >= maxBytes else { return }
+
+    if keep <= 0 {
+        try fm.removeItem(atPath: path)
+        return
+    }
+
+    for i in stride(from: keep - 1, through: 1, by: -1) {
+        let src = "\(path).\(i)"
+        let dst = "\(path).\(i + 1)"
+        if fm.fileExists(atPath: dst) { try? fm.removeItem(atPath: dst) }
+        if fm.fileExists(atPath: src) { try fm.moveItem(atPath: src, toPath: dst) }
+    }
+
+    let first = "\(path).1"
+    if fm.fileExists(atPath: first) { try? fm.removeItem(atPath: first) }
+    try fm.moveItem(atPath: path, toPath: first)
+}
+
+final class ScopedFilesService {
+    let allowedPaths: [String: String]
+    let auditLogPath: String
+    private let now: () -> Date
+    private let isoFormatter = ISO8601DateFormatter()
+
+    init(allowedPaths: [String: String], auditLogPath: String, now: @escaping () -> Date = Date.init) {
+        self.allowedPaths = allowedPaths
+        self.auditLogPath = auditLogPath
+        self.now = now
+    }
+
+    func read(pathName: String, path: String) throws -> ScopedReadResult {
+        let normalizedPathName = pathName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedPathName.isEmpty else {
+            throw ScopedFilesError("path_name is required")
+        }
+
+        guard let allowedRoot = allowedPaths[normalizedPathName] else {
+            throw ScopedFilesError(
+                "Unknown path_name: \(normalizedPathName)",
+                details: ["available_path_names": allowedPaths.keys.sorted()]
+            )
+        }
+
+        let relativePath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !relativePath.isEmpty else {
+            throw ScopedFilesError("path is required")
+        }
+        guard let fullPath = resolveScopedPath(root: allowedRoot, relative: relativePath) else {
+            throw ScopedFilesError("Invalid path")
+        }
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: fullPath, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            throw ScopedFilesError("File not found: \(relativePath)")
+        }
+        guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else {
+            throw ScopedFilesError("Could not read file as UTF-8: \(relativePath)")
+        }
+
+        return ScopedReadResult(
+            pathName: normalizedPathName,
+            path: relativePath,
+            absolutePath: fullPath,
+            content: content
+        )
+    }
+
+    func write(_ request: ScopedWriteRequest) throws -> ScopedWriteResult {
+        let normalizedPathName = request.pathName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedPathName.isEmpty else {
+            throw ScopedFilesError("path_name is required")
+        }
+
+        guard let allowedRoot = allowedPaths[normalizedPathName] else {
+            throw ScopedFilesError(
+                "Unknown path_name: \(normalizedPathName)",
+                details: ["available_path_names": allowedPaths.keys.sorted()]
+            )
+        }
+
+        let relativePath = request.path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !relativePath.isEmpty else {
+            throw ScopedFilesError("path is required")
+        }
+        guard let fullPath = resolveScopedPath(root: allowedRoot, relative: relativePath) else {
+            throw ScopedFilesError("Invalid path")
+        }
+
+        guard let mode = ScopedWriteMode(rawValue: request.mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) else {
+            throw ScopedFilesError("Invalid mode: \(request.mode). Use upsert, append-section, or supersede.")
+        }
+
+        let normalizedAnchor = request.sectionAnchor?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedHeading = request.sectionHeading?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedOperationId = request.operationId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedActor = request.actor?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let timestamp = isoFormatter.string(from: now())
+        let existingContent = try? String(contentsOfFile: fullPath, encoding: .utf8)
+
+        let finalContent: String
+        let resolvedHeading: String?
+
+        switch mode {
+        case .upsert:
+            finalContent = request.content
+            resolvedHeading = nil
+
+        case .appendSection:
+            guard let anchor = normalizedAnchor, !anchor.isEmpty else {
+                throw ScopedFilesError("section_anchor is required for append-section")
+            }
+            if let existingContent = existingContent,
+               findManagedMarkdownSection(in: existingContent, anchor: anchor) != nil {
+                throw ScopedFilesError("Section already exists: \(anchor)")
+            }
+
+            let heading = (normalizedHeading?.isEmpty == false ? normalizedHeading! : humanizeSectionAnchor(anchor))
+            finalContent = appendMarkdownBlock(
+                existingContent ?? "",
+                block: renderManagedMarkdownSection(anchor: anchor, heading: heading, body: request.content)
+            )
+            resolvedHeading = heading
+
+        case .supersede:
+            guard let anchor = normalizedAnchor, !anchor.isEmpty else {
+                throw ScopedFilesError("section_anchor is required for supersede")
+            }
+            guard let existingContent = existingContent else {
+                throw ScopedFilesError("File not found: \(relativePath)")
+            }
+            guard let section = findManagedMarkdownSection(in: existingContent, anchor: anchor) else {
+                throw ScopedFilesError("Section not found: \(anchor)")
+            }
+
+            let heading = !section.title.isEmpty
+                ? section.title
+                : (normalizedHeading?.isEmpty == false ? normalizedHeading! : humanizeSectionAnchor(anchor))
+            let updatedContent = (existingContent as NSString).replacingCharacters(
+                in: section.range,
+                with: renderManagedMarkdownSection(anchor: anchor, heading: heading, body: request.content)
+            )
+            let supersededEntry = renderSupersededEntry(
+                title: heading,
+                anchor: anchor,
+                body: managedMarkdownSectionBody(section.block),
+                operationId: normalizedOperationId,
+                actor: normalizedActor,
+                timestamp: timestamp
+            )
+            finalContent = upsertSupersededSection(content: updatedContent, entry: supersededEntry)
+            resolvedHeading = heading
+        }
+
+        let dir = (fullPath as NSString).deletingLastPathComponent
+        let fm = FileManager.default
+
+        do {
+            try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try finalContent.write(toFile: fullPath, atomically: true, encoding: .utf8)
+        } catch {
+            throw ScopedFilesError("Write failed: \(error.localizedDescription)")
+        }
+
+        let data = finalContent.data(using: .utf8) ?? Data()
+        let sha = sha256Hex(data)
+
+        var auditEntry: [String: Any] = [
+            "ts": timestamp,
+            "action": "scoped_write",
+            "path_name": normalizedPathName,
+            "path": relativePath,
+            "absolute_path": fullPath,
+            "mode": mode.rawValue,
+            "sha256": sha,
+            "bytes": data.count,
+        ]
+        if let anchor = normalizedAnchor, !anchor.isEmpty { auditEntry["section_anchor"] = anchor }
+        if let heading = resolvedHeading, !heading.isEmpty { auditEntry["section_heading"] = heading }
+        if let operationId = normalizedOperationId, !operationId.isEmpty { auditEntry["operation_id"] = operationId }
+        if let actor = normalizedActor, !actor.isEmpty { auditEntry["actor"] = actor }
+        if let metadata = request.metadata,
+           JSONSerialization.isValidJSONObject(["metadata": metadata]) {
+            auditEntry["metadata"] = metadata
+        }
+
+        do {
+            try appendAuditLog(auditEntry)
+        } catch {
+            throw ScopedFilesError(
+                "Audit logging failed after write: \(error.localizedDescription)",
+                details: [
+                    "path_name": normalizedPathName,
+                    "written_path": relativePath,
+                    "sha256": sha,
+                    "absolute_path": fullPath,
+                    "timestamp": timestamp,
+                ]
+            )
+        }
+
+        return ScopedWriteResult(
+            pathName: normalizedPathName,
+            writtenPath: relativePath,
+            absolutePath: fullPath,
+            sha256: sha,
+            timestamp: timestamp
+        )
+    }
+
+    private func appendAuditLog(_ entry: [String: Any]) throws {
+        let path = (auditLogPath as NSString).expandingTildeInPath
+        let dir = (path as NSString).deletingLastPathComponent
+        let fm = FileManager.default
+
+        try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try rotateFileIfNeeded(at: path)
+
+        if !fm.fileExists(atPath: path) {
+            fm.createFile(atPath: path, contents: nil)
+        }
+
+        let line = serializeJSONObject(entry) + "\n"
+        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+        defer { handle.closeFile() }
+        handle.seekToEndOfFile()
+        handle.write(line.data(using: .utf8) ?? Data())
+    }
+}

--- a/Sources/ScopedFilesCore.swift
+++ b/Sources/ScopedFilesCore.swift
@@ -25,14 +25,16 @@ struct ScopedFilesError: Error {
 struct ScopedReadResult {
     let pathName: String
     let path: String
-    let absolutePath: String
     let content: String
 
+    // NOTE: intentionally omits absolute_path. Exposing absolute filesystem
+    // paths to MCP clients reveals user names, directory layout, and the
+    // configured allowlist root. Callers already know the allowed root for
+    // `path_name` out-of-band; they don't need the server to echo it back.
     func jsonObject() -> [String: Any] {
         [
             "path_name": pathName,
             "path": path,
-            "absolute_path": absolutePath,
             "content": content,
         ]
     }
@@ -53,15 +55,17 @@ struct ScopedWriteRequest {
 struct ScopedWriteResult {
     let pathName: String
     let writtenPath: String
-    let absolutePath: String
     let sha256: String
     let timestamp: String
 
+    // NOTE: intentionally omits absolute_path for the same reason as
+    // ScopedReadResult — avoid leaking host filesystem layout to clients.
+    // The server still records the absolute path in the audit log, where
+    // it's useful for forensics.
     func jsonObject() -> [String: Any] {
         [
             "path_name": pathName,
             "written_path": writtenPath,
-            "absolute_path": absolutePath,
             "sha256": sha256,
             "timestamp": timestamp,
         ]
@@ -422,11 +426,17 @@ private func rotateFileIfNeeded(at path: String, maxBytes: UInt64 = 5_000_000, k
     try fm.moveItem(atPath: path, toPath: first)
 }
 
+// Serial queue shared across ScopedFilesService instances so concurrent
+// `scoped_write` calls don't interleave rotate + append on the audit log
+// (or corrupt the log during rotation). Scoped to module-level because
+// the queue must be a singleton regardless of how many service instances
+// are constructed per-request.
+private let auditLogQueue = DispatchQueue(label: "com.macos-mcp.scoped-files.audit", qos: .userInitiated)
+
 final class ScopedFilesService {
     let allowedPaths: [String: String]
     let auditLogPath: String
     private let now: () -> Date
-    private let isoFormatter = ISO8601DateFormatter()
 
     init(allowedPaths: [String: String], auditLogPath: String, now: @escaping () -> Date = Date.init) {
         self.allowedPaths = allowedPaths
@@ -466,7 +476,6 @@ final class ScopedFilesService {
         return ScopedReadResult(
             pathName: normalizedPathName,
             path: relativePath,
-            absolutePath: fullPath,
             content: content
         )
     }
@@ -500,7 +509,10 @@ final class ScopedFilesService {
         let normalizedHeading = request.sectionHeading?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedOperationId = request.operationId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedActor = request.actor?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let timestamp = isoFormatter.string(from: now())
+        // Instantiate the formatter locally per call — ISO8601DateFormatter
+        // is not documented as thread-safe, and `write(_:)` runs concurrently
+        // from the MCP server's dispatch queue.
+        let timestamp = ISO8601DateFormatter().string(from: now())
         let existingContent = try? String(contentsOfFile: fullPath, encoding: .utf8)
 
         let finalContent: String
@@ -592,13 +604,14 @@ final class ScopedFilesService {
         do {
             try appendAuditLog(auditEntry)
         } catch {
+            // Audit log is append-only and server-internal; don't echo
+            // absolute_path back to the client in error details.
             throw ScopedFilesError(
                 "Audit logging failed after write: \(error.localizedDescription)",
                 details: [
                     "path_name": normalizedPathName,
                     "written_path": relativePath,
                     "sha256": sha,
-                    "absolute_path": fullPath,
                     "timestamp": timestamp,
                 ]
             )
@@ -607,28 +620,36 @@ final class ScopedFilesService {
         return ScopedWriteResult(
             pathName: normalizedPathName,
             writtenPath: relativePath,
-            absolutePath: fullPath,
             sha256: sha,
             timestamp: timestamp
         )
     }
 
     private func appendAuditLog(_ entry: [String: Any]) throws {
+        // Serialize rotate + append through a single process-wide queue so
+        // concurrent writes from the MCP server's request-handler queue
+        // can't interleave mid-rotation or produce partial-line writes.
         let path = (auditLogPath as NSString).expandingTildeInPath
-        let dir = (path as NSString).deletingLastPathComponent
-        let fm = FileManager.default
-
-        try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        try rotateFileIfNeeded(at: path)
-
-        if !fm.fileExists(atPath: path) {
-            fm.createFile(atPath: path, contents: nil)
-        }
-
         let line = serializeJSONObject(entry) + "\n"
-        let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
-        defer { handle.closeFile() }
-        handle.seekToEndOfFile()
-        handle.write(line.data(using: .utf8) ?? Data())
+
+        var caught: Error?
+        auditLogQueue.sync {
+            let dir = (path as NSString).deletingLastPathComponent
+            let fm = FileManager.default
+            do {
+                try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+                try rotateFileIfNeeded(at: path)
+                if !fm.fileExists(atPath: path) {
+                    fm.createFile(atPath: path, contents: nil)
+                }
+                let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+                defer { handle.closeFile() }
+                handle.seekToEndOfFile()
+                handle.write(line.data(using: .utf8) ?? Data())
+            } catch {
+                caught = error
+            }
+        }
+        if let caught = caught { throw caught }
     }
 }

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -552,11 +552,19 @@ private func vaultSearch(_ query: String, contentSearch: Bool) -> String {
 
 // MARK: - Scoped File Helpers
 
-private let scopedFilesService = ScopedFilesService(
-    allowedPaths: loadAllowedPaths(from: ProcessInfo.processInfo.environment),
-    auditLogPath: ProcessInfo.processInfo.environment["ALLOWED_PATHS_AUDIT_LOG_PATH"]
-        ?? NSHomeDirectory() + "/.local/share/work-work/logs/allowed-paths-audit.log"
-)
+// Fresh ScopedFilesService per request so there is no shared mutable state
+// across concurrent MCP tool calls. The service itself holds only immutable
+// config (`allowedPaths`, `auditLogPath`). Re-reading ALLOWED_PATHS_JSON on
+// each call is trivial overhead and picks up env changes without requiring
+// a process restart. Audit-log writes are serialized internally via a
+// module-level queue in ScopedFilesCore.
+private var scopedFilesService: ScopedFilesService {
+    ScopedFilesService(
+        allowedPaths: loadAllowedPaths(from: ProcessInfo.processInfo.environment),
+        auditLogPath: ProcessInfo.processInfo.environment["ALLOWED_PATHS_AUDIT_LOG_PATH"]
+            ?? NSHomeDirectory() + "/.local/share/work-work/logs/allowed-paths-audit.log"
+    )
+}
 
 private func scopedRead(pathName: String, path: String) -> String {
     do {

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -16,6 +16,7 @@ private enum LogComponent: String {
     case typing = "typing"
     case webhook = "webhook"
     case vault = "vault"
+    case files = "files"
     case server = "server"
 }
 
@@ -141,6 +142,37 @@ private let mcpTools: [[String: Any]] = [
                 "content_search": ["type": "boolean", "description": "Search inside file contents (default: filename only)"],
             ],
             "required": ["query"],
+        ] as [String: Any],
+    ],
+    [
+        "name": "scoped_read",
+        "description": "Read a text file from a named, allowlisted path.",
+        "inputSchema": [
+            "type": "object",
+            "properties": [
+                "path_name": ["type": "string", "description": "Configured allowlisted path name, like notes or ops"],
+                "path": ["type": "string", "description": "Relative path under the named allowed path"],
+            ],
+            "required": ["path_name", "path"],
+        ] as [String: Any],
+    ],
+    [
+        "name": "scoped_write",
+        "description": "Write markdown/text content under a named, allowlisted path. Supports whole-file upserts and anchored section append/supersede operations with audit logging.",
+        "inputSchema": [
+            "type": "object",
+            "properties": [
+                "path_name": ["type": "string", "description": "Configured allowlisted path name, like notes or ops"],
+                "path": ["type": "string", "description": "Relative path under the named allowed path"],
+                "content": ["type": "string", "description": "Content to write. For append-section/supersede, this is the section body."],
+                "mode": ["type": "string", "enum": ["upsert", "append-section", "supersede"]],
+                "section_anchor": ["type": "string", "description": "Stable anchor for append-section/supersede, e.g. deploy-target"],
+                "section_heading": ["type": "string", "description": "Optional human-readable heading for append-section/supersede. Defaults to a title-cased version of section_anchor."],
+                "operation_id": ["type": "string", "description": "Optional operation identifier for audit logging"],
+                "actor": ["type": "string", "description": "Optional actor identifier for audit logging"],
+                "metadata": ["type": "object", "description": "Optional JSON metadata to include in the audit log"],
+            ],
+            "required": ["path_name", "path", "content", "mode"],
         ] as [String: Any],
     ],
     [
@@ -277,6 +309,23 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
         return vaultList(input["path"] as? String ?? "")
     case "vault_search":
         return vaultSearch(input["query"] as? String ?? "", contentSearch: input["content_search"] as? Bool ?? false)
+    case "scoped_read":
+        return scopedRead(
+            pathName: input["path_name"] as? String ?? "",
+            path: input["path"] as? String ?? ""
+        )
+    case "scoped_write":
+        return scopedWrite(
+            pathName: input["path_name"] as? String ?? "",
+            path: input["path"] as? String ?? "",
+            content: input["content"] as? String ?? "",
+            mode: input["mode"] as? String ?? "",
+            sectionAnchor: input["section_anchor"] as? String,
+            sectionHeading: input["section_heading"] as? String,
+            operationId: input["operation_id"] as? String,
+            actor: input["actor"] as? String,
+            metadata: input["metadata"]
+        )
     case "check_messages":
         args = ["messages", "check"]
         if let phone = input["phone"] as? String, !phone.isEmpty { args += ["--phone", phone] }
@@ -363,7 +412,7 @@ private func downloadFile(_ urlString: String, filename: String?) -> String {
     // Extra safety: reject any remaining traversal
     let name = rawName.replacingOccurrences(of: "..", with: "_")
 
-    guard let destPath = safePath(root: downloadDir, relative: name) else {
+    guard let destPath = resolveScopedPath(root: downloadDir, relative: name) else {
         return "{\"error\": \"Invalid filename\"}"
     }
 
@@ -403,27 +452,13 @@ private func downloadFile(_ urlString: String, filename: String?) -> String {
     return resultJSON
 }
 
-// MARK: - Path Safety
-
-/// Resolve a relative path against a root and verify it doesn't escape.
-/// Returns nil if the path escapes the root (path traversal).
-private func safePath(root: String, relative: String) -> String? {
-    let full = (root as NSString).appendingPathComponent(relative)
-    let resolved = URL(fileURLWithPath: full).standardized.path
-    let resolvedRoot = URL(fileURLWithPath: root).standardized.path
-    guard resolved == resolvedRoot || resolved.hasPrefix(resolvedRoot + "/") else {
-        return nil
-    }
-    return resolved
-}
-
 // MARK: - Vault Helpers
 
 private let vaultRoot = (ProcessInfo.processInfo.environment["OBSIDIAN_VAULT_PATH"]
     ?? NSHomeDirectory() + "/Library/Mobile Documents/com~apple~CloudDocs/Obsidian")
 
 private func vaultRead(_ path: String) -> String {
-    guard let fullPath = safePath(root: vaultRoot, relative: path) else {
+    guard let fullPath = resolveScopedPath(root: vaultRoot, relative: path) else {
         log(.error, .vault, "Path traversal blocked", extra: ["path": path])
         return "{\"error\": \"Invalid path\"}"
     }
@@ -442,7 +477,7 @@ private func vaultRead(_ path: String) -> String {
 }
 
 private func vaultWrite(_ path: String, content: String) -> String {
-    guard let fullPath = safePath(root: vaultRoot, relative: path) else {
+    guard let fullPath = resolveScopedPath(root: vaultRoot, relative: path) else {
         log(.error, .vault, "Path traversal blocked", extra: ["path": path])
         return "{\"error\": \"Invalid path\"}"
     }
@@ -463,7 +498,7 @@ private func vaultList(_ path: String) -> String {
     if path.isEmpty {
         fullPath = vaultRoot
     } else {
-        guard let resolved = safePath(root: vaultRoot, relative: path) else {
+        guard let resolved = resolveScopedPath(root: vaultRoot, relative: path) else {
             log(.error, .vault, "Path traversal blocked", extra: ["path": path])
             return "{\"error\": \"Invalid path\"}"
         }
@@ -513,6 +548,84 @@ private func vaultSearch(_ query: String, contentSearch: Bool) -> String {
         return "{\"error\": \"Serialization failed\"}"
     }
     return json
+}
+
+// MARK: - Scoped File Helpers
+
+private let scopedFilesService = ScopedFilesService(
+    allowedPaths: loadAllowedPaths(from: ProcessInfo.processInfo.environment),
+    auditLogPath: ProcessInfo.processInfo.environment["ALLOWED_PATHS_AUDIT_LOG_PATH"]
+        ?? NSHomeDirectory() + "/.local/share/work-work/logs/allowed-paths-audit.log"
+)
+
+private func scopedRead(pathName: String, path: String) -> String {
+    do {
+        let result = try scopedFilesService.read(pathName: pathName, path: path)
+        return serializeJSONObject(result.jsonObject())
+    } catch let error as ScopedFilesError {
+        log(.error, .files, "Scoped read failed", extra: [
+            "path_name": pathName,
+            "path": path,
+            "error": error.message,
+        ])
+        return serializeJSONObject(error.jsonObject())
+    } catch {
+        log(.error, .files, "Scoped read failed", extra: [
+            "path_name": pathName,
+            "path": path,
+            "error": error.localizedDescription,
+        ])
+        return serializeJSONObject(["error": error.localizedDescription])
+    }
+}
+
+private func scopedWrite(
+    pathName: String,
+    path: String,
+    content: String,
+    mode: String,
+    sectionAnchor: String?,
+    sectionHeading: String?,
+    operationId: String?,
+    actor: String?,
+    metadata: Any?
+) -> String {
+    do {
+        let result = try scopedFilesService.write(ScopedWriteRequest(
+            pathName: pathName,
+            path: path,
+            content: content,
+            mode: mode,
+            sectionAnchor: sectionAnchor,
+            sectionHeading: sectionHeading,
+            operationId: operationId,
+            actor: actor,
+            metadata: metadata
+        ))
+        log(.info, .files, "Scoped write complete", extra: [
+            "path_name": result.pathName,
+            "path": result.writtenPath,
+            "mode": mode,
+            "sha256": result.sha256,
+        ])
+        return serializeJSONObject(result.jsonObject())
+    } catch let error as ScopedFilesError {
+        log(.error, .files, "Scoped write failed", extra: [
+            "path_name": pathName,
+            "path": path,
+            "mode": mode,
+            "error": error.message,
+        ])
+        return serializeJSONObject(error.jsonObject())
+    } catch {
+        log(.error, .files, "Scoped write failed", extra: [
+            "path_name": pathName,
+            "path": path,
+            "mode": mode,
+            "error": error.localizedDescription,
+        ])
+        return serializeJSONObject(["error": error.localizedDescription])
+    }
 }
 
 // MARK: - JSON-RPC Helpers

--- a/Tests/ScopedFilesCoreTests/ScopedFilesCoreTests.swift
+++ b/Tests/ScopedFilesCoreTests/ScopedFilesCoreTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+@testable import ScopedFilesCore
+
+final class ScopedFilesCoreTests: XCTestCase {
+    private let fm = FileManager.default
+
+    private func makeTempDir() throws -> URL {
+        let dir = fm.temporaryDirectory.appendingPathComponent("macos-mcp-tests-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func fixedService(root: URL, auditLog: URL) -> ScopedFilesService {
+        ScopedFilesService(
+            allowedPaths: ["test": root.path],
+            auditLogPath: auditLog.path,
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    func testLoadAllowedPathsParsesJSON() {
+        let paths = loadAllowedPaths(from: [
+            "ALLOWED_PATHS_JSON": "{\"notes\":\"/tmp/notes\",\"ops\":\"/tmp/ops\"}"
+        ])
+
+        XCTAssertEqual(paths["notes"], "/tmp/notes")
+        XCTAssertEqual(paths["ops"], "/tmp/ops")
+    }
+
+    func testResolveScopedPathAllowsInternalSymlinkAndRejectsEscapes() throws {
+        let root = try makeTempDir()
+        defer { try? fm.removeItem(at: root) }
+
+        let realDir = root.appendingPathComponent("real", isDirectory: true)
+        try fm.createDirectory(at: realDir, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(atPath: root.appendingPathComponent("inside-link").path, withDestinationPath: realDir.path)
+
+        let outside = try makeTempDir()
+        defer { try? fm.removeItem(at: outside) }
+        try fm.createSymbolicLink(atPath: root.appendingPathComponent("escape-link").path, withDestinationPath: outside.path)
+
+        let allowed = resolveScopedPath(root: root.path, relative: "inside-link/file.txt")
+        let rejected = resolveScopedPath(root: root.path, relative: "escape-link/file.txt")
+        let traversal = resolveScopedPath(root: root.path, relative: "../nope.txt")
+
+        XCTAssertEqual(allowed, realDir.appendingPathComponent("file.txt").path)
+        XCTAssertNil(rejected)
+        XCTAssertNil(traversal)
+    }
+
+    func testScopedWriteUpsertAndReadRoundTrip() throws {
+        let root = try makeTempDir()
+        defer { try? fm.removeItem(at: root) }
+        let auditLog = root.appendingPathComponent("audit.log")
+        let service = fixedService(root: root, auditLog: auditLog)
+
+        let writeResult = try service.write(ScopedWriteRequest(
+            pathName: "test",
+            path: "notes/hello.md",
+            content: "Hello world\n",
+            mode: "upsert",
+            sectionAnchor: nil,
+            sectionHeading: nil,
+            operationId: "op-1",
+            actor: "tester",
+            metadata: ["source": "unit-test"]
+        ))
+
+        let readResult = try service.read(pathName: "test", path: "notes/hello.md")
+        let onDisk = try String(contentsOf: root.appendingPathComponent("notes/hello.md"), encoding: .utf8)
+        let auditText = try String(contentsOf: auditLog, encoding: .utf8)
+
+        XCTAssertEqual(readResult.content, "Hello world\n")
+        XCTAssertEqual(onDisk, "Hello world\n")
+        XCTAssertEqual(writeResult.pathName, "test")
+        XCTAssertEqual(writeResult.writtenPath, "notes/hello.md")
+        XCTAssertFalse(writeResult.sha256.isEmpty)
+        XCTAssertTrue(auditText.contains("\"action\":\"scoped_write\""))
+        XCTAssertTrue(auditText.contains("\"path_name\":\"test\""))
+        XCTAssertTrue(auditText.contains("\"operation_id\":\"op-1\""))
+    }
+
+    func testAppendSectionAddsManagedSection() throws {
+        let root = try makeTempDir()
+        defer { try? fm.removeItem(at: root) }
+        let service = fixedService(root: root, auditLog: root.appendingPathComponent("audit.log"))
+
+        _ = try service.write(ScopedWriteRequest(
+            pathName: "test",
+            path: "notes/page.md",
+            content: "# Title\n",
+            mode: "upsert",
+            sectionAnchor: nil,
+            sectionHeading: nil,
+            operationId: nil,
+            actor: nil,
+            metadata: nil
+        ))
+
+        _ = try service.write(ScopedWriteRequest(
+            pathName: "test",
+            path: "notes/page.md",
+            content: "Fresh body",
+            mode: "append-section",
+            sectionAnchor: "deploy-target",
+            sectionHeading: "Deploy Target",
+            operationId: nil,
+            actor: nil,
+            metadata: nil
+        ))
+
+        let content = try String(contentsOf: root.appendingPathComponent("notes/page.md"), encoding: .utf8)
+        XCTAssertTrue(content.contains("## Deploy Target"))
+        XCTAssertTrue(content.contains("<!-- macos-mcp:section_anchor=deploy-target -->"))
+        XCTAssertTrue(content.contains("Fresh body"))
+    }
+
+    func testSupersedeReplacesSectionAndArchivesOldBody() throws {
+        let root = try makeTempDir()
+        defer { try? fm.removeItem(at: root) }
+        let service = fixedService(root: root, auditLog: root.appendingPathComponent("audit.log"))
+
+        let initial = """
+        # Title
+
+        ## Deploy Target
+        <!-- macos-mcp:section_anchor=deploy-target -->
+
+        Old body
+        """
+
+        _ = try service.write(ScopedWriteRequest(
+            pathName: "test",
+            path: "notes/page.md",
+            content: initial,
+            mode: "upsert",
+            sectionAnchor: nil,
+            sectionHeading: nil,
+            operationId: nil,
+            actor: nil,
+            metadata: nil
+        ))
+
+        _ = try service.write(ScopedWriteRequest(
+            pathName: "test",
+            path: "notes/page.md",
+            content: "New body",
+            mode: "supersede",
+            sectionAnchor: "deploy-target",
+            sectionHeading: nil,
+            operationId: "op-2",
+            actor: "tester",
+            metadata: nil
+        ))
+
+        let content = try String(contentsOf: root.appendingPathComponent("notes/page.md"), encoding: .utf8)
+
+        XCTAssertTrue(content.contains("## Deploy Target"))
+        XCTAssertTrue(content.contains("New body"))
+        XCTAssertTrue(content.contains("## Superseded"))
+        XCTAssertTrue(content.contains("### Deploy Target"))
+        XCTAssertTrue(content.contains("Old body"))
+        XCTAssertTrue(content.contains("<!-- macos-mcp:operation_id=op-2 -->"))
+        XCTAssertTrue(content.contains("<!-- macos-mcp:actor=tester -->"))
+    }
+}

--- a/scripts/smoke-scoped-files.sh
+++ b/scripts/smoke-scoped-files.sh
@@ -6,6 +6,22 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
+# Preflight: we shell out to curl + python3 extensively. macOS 12+ ships
+# both at /usr/bin/, but surface a clear error when they're absent rather
+# than failing partway through with a confusing trace.
+missing=()
+for tool in curl python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    missing+=("$tool")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "smoke-scoped-files.sh: required tools not on PATH: ${missing[*]}" >&2
+  echo "  curl: ships with macOS (Command Line Tools)." >&2
+  echo "  python3: ships with macOS 12+ or install via 'xcode-select --install'." >&2
+  exit 1
+fi
+
 BINARY="${1:-.build/macos-mcp-unsigned}"
 PORT="${PORT:-9320}"
 SECRET="${MCP_SECRET:-test-secret}"

--- a/scripts/smoke-scoped-files.sh
+++ b/scripts/smoke-scoped-files.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "smoke-scoped-files.sh must run on macOS" >&2
+  exit 1
+fi
+
+BINARY="${1:-.build/macos-mcp-unsigned}"
+PORT="${PORT:-9320}"
+SECRET="${MCP_SECRET:-test-secret}"
+TMP_DIR="$(mktemp -d /tmp/macos-mcp-scoped-files.XXXXXX)"
+TEST_ROOT="$TMP_DIR/files"
+AUDIT_LOG="$TMP_DIR/audit.log"
+SERVER_LOG="$TMP_DIR/server.log"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TEST_ROOT"
+export ALLOWED_PATHS_JSON="{\"test\":\"$TEST_ROOT\"}"
+export ALLOWED_PATHS_AUDIT_LOG_PATH="$AUDIT_LOG"
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "Binary not found or not executable: $BINARY" >&2
+  exit 1
+fi
+
+"$BINARY" serve --host 127.0.0.1 --port "$PORT" --mcp-secret "$SECRET" > /dev/null 2>"$SERVER_LOG" &
+SERVER_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl -fsS "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! curl -fsS "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
+  echo "Server did not become healthy" >&2
+  cat "$SERVER_LOG" >&2 || true
+  exit 1
+fi
+
+call_mcp() {
+  local payload="$1"
+  curl -fsS \
+    -X POST "http://127.0.0.1:$PORT/mcp" \
+    -H "Authorization: Bearer $SECRET" \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'Content-Type: application/json' \
+    -d "$payload" | python3 -c '
+import sys
+text = sys.stdin.read()
+last = None
+for line in text.splitlines():
+    if line.startswith("data: "):
+        last = line[6:]
+if last is None:
+    raise SystemExit("No SSE data in response")
+print(last)
+'
+}
+
+call_tool() {
+  local name="$1"
+  local arguments_json="$2"
+  local payload
+  payload=$(cat <<JSON
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"$name","arguments":$arguments_json}}
+JSON
+)
+  call_mcp "$payload" | python3 -c '
+import json, sys
+outer = json.load(sys.stdin)
+print(outer["result"]["content"][0]["text"])
+'
+}
+
+TOOLS_PAYLOAD='{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+call_mcp "$TOOLS_PAYLOAD" | python3 -c '
+import json, sys
+outer = json.load(sys.stdin)
+names = {tool["name"] for tool in outer["result"]["tools"]}
+required = {"scoped_read", "scoped_write"}
+missing = required - names
+if missing:
+    raise SystemExit(f"Missing tools: {sorted(missing)}")
+'
+
+WRITE_RESULT="$(call_tool "scoped_write" '{"path_name":"test","path":"notes/hello.md","content":"Hello world","mode":"upsert"}')"
+printf '%s' "$WRITE_RESULT" | python3 -c '
+import json, sys
+result = json.load(sys.stdin)
+assert result["path_name"] == "test"
+assert result["written_path"] == "notes/hello.md"
+assert result["sha256"]
+'
+
+READ_RESULT="$(call_tool "scoped_read" '{"path_name":"test","path":"notes/hello.md"}')"
+printf '%s' "$READ_RESULT" | python3 -c '
+import json, sys
+result = json.load(sys.stdin)
+assert result["content"] == "Hello world"
+'
+
+call_tool "scoped_write" '{"path_name":"test","path":"notes/page.md","content":"# Title","mode":"upsert"}' > /dev/null
+call_tool "scoped_write" '{"path_name":"test","path":"notes/page.md","content":"First body","mode":"append-section","section_anchor":"deploy-target","section_heading":"Deploy Target"}' > /dev/null
+call_tool "scoped_write" '{"path_name":"test","path":"notes/page.md","content":"Second body","mode":"supersede","section_anchor":"deploy-target","operation_id":"smoke-1","actor":"smoke-test"}' > /dev/null
+
+python3 - <<PY
+from pathlib import Path
+content = Path("$TEST_ROOT/notes/page.md").read_text()
+audit = Path("$AUDIT_LOG").read_text()
+assert "## Deploy Target" in content
+assert "Second body" in content
+assert "## Superseded" in content
+assert "First body" in content
+assert '"action":"scoped_write"' in audit
+print("scoped file smoke test passed")
+PY


### PR DESCRIPTION
## Summary
- extract allowlisted scoped file logic into a reusable core module
- add SwiftPM logic tests for path resolution and markdown transforms
- add macOS smoke test for `scoped_read` / `scoped_write`
- add make targets for logic and build/smoke test flows

## Verification
- `git diff --check`
- `bash -n scripts/smoke-scoped-files.sh`

## Not run here
- `swift test`
- `make build`
- `make test-build`

This environment is Linux and does not have Swift/macOS toolchains, so compile/build verification still needs to run on Swift-enabled Linux/macOS respectively.
