### PR TITLE
imessage-daemon: allow MACOS_MCP env override

### DIFF
--- a/skills/imessage/daemon/imessage-auto-reply-daemon.sh
+++ b/skills/imessage/daemon/imessage-auto-reply-daemon.sh
@@ -25,7 +25,11 @@ trap 'exit 0' TERM INT HUP
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-MACOS_MCP="$PROJECT_ROOT/macos-mcp"
+# Default to the in-project build, but let the caller override with
+# $MACOS_MCP so the daemon can point at a canonical install path
+# (e.g. ~/.local/bin/macos-mcp produced by `make deploy`) without
+# keeping a second binary alongside the project-root copy.
+MACOS_MCP="${MACOS_MCP:-$PROJECT_ROOT/macos-mcp}"
 TMP_DIR="${IMESSAGE_TMP_DIR:-$HOME/tmp/imessage}"
 LOG_FILE="$TMP_DIR/imessage-auto-reply.log"
 

--- a/skills/imessage/daemon/imessage-auto-reply-daemon.sh
+++ b/skills/imessage/daemon/imessage-auto-reply-daemon.sh
@@ -25,6 +25,24 @@ trap 'exit 0' TERM INT HUP
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Load environment variables from $PROJECT_ROOT/.env *before* the
+# config assignments below resolve. Sourcing after those assignments
+# (the earlier behavior) meant .env could never override them — every
+# ${VAR:-default}/${VAR:?required} had already captured the pre-.env
+# state.
+#
+# Precedence with this ordering: .env > launchd-exported env > built-in
+# defaults. A local dev's .env wins over a launchd plist's
+# EnvironmentVariables for variables set in both. On Minerva today
+# there is no project-root .env, so launchd values are what the script
+# sees. If a future operator needs launchd to win over .env, reverse
+# the layering by reading launchd env into a saved map before sourcing
+# and restoring after.
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    source "$PROJECT_ROOT/.env"
+fi
+
 # Default to the in-project build, but let the caller override with
 # $MACOS_MCP so the daemon can point at a canonical install path
 # (e.g. ~/.local/bin/macos-mcp produced by `make deploy`) without
@@ -43,11 +61,6 @@ AGENT_TIMEOUT="${IMESSAGE_AGENT_TIMEOUT:-1800}"
 AGENT_SPEC_PATH="${MACOS_MCP_AGENT_PATH:-}"
 AGENT_RUNNER="$SCRIPT_DIR/agent-runner.py"
 AGENT_PYTHON="$SCRIPT_DIR/.venv/bin/python3"
-
-# Load environment variables if .env exists
-if [ -f "$PROJECT_ROOT/.env" ]; then
-    source "$PROJECT_ROOT/.env"
-fi
 
 # Verify binary exists
 if [ ! -x "$MACOS_MCP" ]; then


### PR DESCRIPTION
## Summary

Single-line change to `skills/imessage/daemon/imessage-auto-reply-daemon.sh` — replace the hardcoded binary assignment with an env-overridable one:

```diff
-MACOS_MCP="$PROJECT_ROOT/macos-mcp"
+MACOS_MCP="${MACOS_MCP:-$PROJECT_ROOT/macos-mcp}"
```

## Why

On Minerva, the canonical macos-mcp binary lives at `~/.local/bin/macos-mcp` (per the Makefile's `$(INSTALLED)` convention). The daemon was shelling out to a separate binary at the project-root path, which meant:
- Two binaries on the same box (one canonical, one daemon-only).
- Silent drift when `make deploy` updates the canonical binary but the project-root copy ages out.
- More surface area to get wrong.

With this change, the daemon launchd plist on Minerva can set `MACOS_MCP=/Users/administrator/.local/bin/macos-mcp` and both the serve-mode launchd agent and the auto-reply daemon point at the same binary.

## Test plan

Local dev flow unchanged — without MACOS_MCP set, falls back to `$PROJECT_ROOT/macos-mcp` as before.

Production flow (Minerva): accompanied by felipe/bramble PR adding MACOS_MCP to `hosts/minerva/launchd/com.claude.imessage-daemon.plist`.