### PR TITLE
feat(daemon): contact/group allowlist for the iMessage poller

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     ],
     products: [
         .library(name: "ScopedFilesCore", targets: ["ScopedFilesCore"]),
+        .library(name: "AccessControl", targets: ["AccessControl"]),
     ],
     targets: [
         .target(
@@ -19,6 +20,16 @@ let package = Package(
             name: "ScopedFilesCoreTests",
             dependencies: ["ScopedFilesCore"],
             path: "Tests/ScopedFilesCoreTests"
+        ),
+        .target(
+            name: "AccessControl",
+            path: "Sources",
+            sources: ["AccessControl.swift"]
+        ),
+        .testTarget(
+            name: "AccessControlTests",
+            dependencies: ["AccessControl"],
+            path: "Tests/AccessControlTests"
         ),
     ]
 )

--- a/Sources/AccessControl.swift
+++ b/Sources/AccessControl.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// MARK: - Access Control
+
+/// Controls which senders and group chats the iMessage poller is allowed to
+/// forward to the webhook. Loads from the `MACOS_MCP_OWNER_PHONE` env var plus
+/// an optional JSON config file (`MACOS_MCP_ACCESS_FILE`, default
+/// `~/.config/macos-mcp/access.json`):
+///
+///     {
+///       "allowFrom": ["+15551234567", "+15559876543"],
+///       "groups": ["chat646855985291785786"]
+///     }
+///
+/// `groups` holds `chat_identifier` values as reported by the poller
+/// (`PolledMessage.chat`), i.e. the numeric `chat<digits>` form — not the
+/// legacy `service;+;guid` string.
+///
+/// When both sources are empty the config is considered unconfigured
+/// (`isEmpty == true`); callers should leave the gate inactive in that case so
+/// an operator opts into filtering explicitly rather than silently losing every
+/// message.
+struct AccessConfig {
+    let allowFrom: Set<String>
+    let allowedGroups: Set<String>
+    let isEmpty: Bool
+
+    static func load(environment: [String: String] = ProcessInfo.processInfo.environment) -> AccessConfig {
+        let ownerPhone = environment["MACOS_MCP_OWNER_PHONE"] ?? ""
+        let configPath = environment["MACOS_MCP_ACCESS_FILE"]
+            ?? NSHomeDirectory() + "/.config/macos-mcp/access.json"
+
+        var allowFrom = Set<String>()
+        var allowedGroups = Set<String>()
+
+        if !ownerPhone.isEmpty {
+            allowFrom.insert(normalizePhone(ownerPhone))
+        }
+
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: configPath)),
+           let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
+            if let phones = json["allowFrom"] as? [String] {
+                for phone in phones {
+                    let normalized = normalizePhone(phone)
+                    if !normalized.isEmpty { allowFrom.insert(normalized) }
+                }
+            }
+            if let groups = json["groups"] as? [String] {
+                for g in groups where !g.isEmpty { allowedGroups.insert(g) }
+            }
+        }
+
+        return AccessConfig(
+            allowFrom: allowFrom,
+            allowedGroups: allowedGroups,
+            isEmpty: allowFrom.isEmpty && allowedGroups.isEmpty
+        )
+    }
+
+    /// Whether an inbound message from `handle` in `chat` (a `chat_identifier`)
+    /// is allowed. Group chats — whose identifier is the `chat<digits>` form —
+    /// match against `allowedGroups`; everything else is treated as a direct
+    /// message and matches the sender against `allowFrom`.
+    ///
+    /// Returns `false` for an empty (unconfigured) config, so a configured
+    /// caller fails closed; the poller guards on `isEmpty` before calling to
+    /// keep the unconfigured default permissive.
+    func isAllowed(from handle: String, chat: String) -> Bool {
+        if isEmpty { return false }
+        if AccessConfig.isGroupIdentifier(chat) {
+            return allowedGroups.contains(chat)
+        }
+        return allowFrom.contains(AccessConfig.normalizePhone(handle))
+    }
+
+    /// A group `chat_identifier` is the literal `chat` followed by digits
+    /// (e.g. `chat646855985291785786`). Requiring the numeric suffix avoids
+    /// misclassifying handles such as `chat@example.com` as groups.
+    static func isGroupIdentifier(_ chat: String) -> Bool {
+        guard chat.hasPrefix("chat") else { return false }
+        let suffix = chat.dropFirst(4)
+        return !suffix.isEmpty && suffix.allSatisfy { $0.isNumber }
+    }
+
+    /// Normalize a phone number to E.164 for consistent matching. Non-phone
+    /// handles (email addresses) are lowercased and returned unchanged.
+    static func normalizePhone(_ phone: String) -> String {
+        let stripped = phone.filter { $0.isNumber || $0 == "+" }
+        if stripped.hasPrefix("+") { return stripped }
+        let digits = stripped.filter { $0.isNumber }
+        if digits.count == 11 && digits.hasPrefix("1") { return "+" + digits }
+        if digits.count == 10 { return "+1" + digits }
+        return phone.lowercased()
+    }
+}

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -1121,6 +1121,19 @@ private func startPoller(
             "mode": "in-process",
         ])
 
+        // Sender/group allowlist. When unconfigured the gate is inactive and
+        // all inbound messages are forwarded (preserves prior behavior); set
+        // MACOS_MCP_OWNER_PHONE or ~/.config/macos-mcp/access.json to restrict.
+        let accessConfig = AccessConfig.load()
+        if accessConfig.isEmpty {
+            log(.warn, .poller, "Access control not configured — forwarding all inbound messages")
+        } else {
+            log(.info, .poller, "Access control active", extra: [
+                "allowed_phones": accessConfig.allowFrom.count,
+                "allowed_groups": accessConfig.allowedGroups.count,
+            ])
+        }
+
         // WAL watcher: signals semaphore on DB changes for instant pickup
         let walSemaphore = DispatchSemaphore(value: 0)
         let walSource = startWALWatcher(semaphore: walSemaphore, queue: pollerQueue)
@@ -1170,6 +1183,13 @@ private func startPoller(
 
                 let thread = msg.chat.isEmpty ? msg.from : msg.chat
                 if thread.isEmpty { continue }
+
+                // Drop senders/groups not on the allowlist. The watermark has
+                // already advanced above, so blocked messages are not re-seen.
+                if !accessConfig.isEmpty && !accessConfig.isAllowed(from: msg.from, chat: msg.chat) {
+                    log(.info, .poller, "Blocked by access control", extra: ["rowid": rowid, "from": msg.from, "chat": msg.chat])
+                    continue
+                }
 
                 log(.info, .poller, "New message", extra: ["rowid": rowid, "thread": thread, "preview": String(msg.text.prefix(80))])
                 pending.append((text: msg.text, thread: thread, rowid: rowid))

--- a/Tests/AccessControlTests/AccessControlTests.swift
+++ b/Tests/AccessControlTests/AccessControlTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+@testable import AccessControl
+
+final class AccessControlTests: XCTestCase {
+    private let fm = FileManager.default
+
+    private func writeAccessFile(_ json: String) throws -> String {
+        let path = fm.temporaryDirectory
+            .appendingPathComponent("macos-mcp-access-\(UUID().uuidString).json").path
+        try json.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    // MARK: - load()
+
+    func testEmptyWhenNothingConfigured() {
+        let config = AccessConfig.load(environment: ["MACOS_MCP_ACCESS_FILE": "/nonexistent/path.json"])
+        XCTAssertTrue(config.isEmpty)
+        // An unconfigured config denies everything; the poller guards on isEmpty
+        // so the unconfigured runtime default stays permissive.
+        XCTAssertFalse(config.isAllowed(from: "+15551234567", chat: "+15551234567"))
+    }
+
+    func testOwnerPhoneSeedsAllowlist() {
+        let config = AccessConfig.load(environment: [
+            "MACOS_MCP_OWNER_PHONE": "(555) 123-4567",
+            "MACOS_MCP_ACCESS_FILE": "/nonexistent/path.json",
+        ])
+        XCTAssertFalse(config.isEmpty)
+        XCTAssertTrue(config.isAllowed(from: "+15551234567", chat: "+15551234567"))
+        XCTAssertFalse(config.isAllowed(from: "+15559999999", chat: "+15559999999"))
+    }
+
+    func testConfigFileParsesPhonesAndGroups() throws {
+        let path = try writeAccessFile("""
+        {"allowFrom": ["+15551234567", "5559876543"], "groups": ["chat646855985291785786"]}
+        """)
+        let config = AccessConfig.load(environment: ["MACOS_MCP_ACCESS_FILE": path])
+        XCTAssertEqual(config.allowFrom, ["+15551234567", "+15559876543"])
+        XCTAssertEqual(config.allowedGroups, ["chat646855985291785786"])
+    }
+
+    func testOwnerPhoneAndFileMerge() throws {
+        let path = try writeAccessFile(#"{"allowFrom": ["+15559876543"]}"#)
+        let config = AccessConfig.load(environment: [
+            "MACOS_MCP_OWNER_PHONE": "+15551234567",
+            "MACOS_MCP_ACCESS_FILE": path,
+        ])
+        XCTAssertEqual(config.allowFrom, ["+15551234567", "+15559876543"])
+    }
+
+    // MARK: - isAllowed()
+
+    func testDirectMessageAllowlist() throws {
+        let path = try writeAccessFile(#"{"allowFrom": ["+15551234567"]}"#)
+        let config = AccessConfig.load(environment: ["MACOS_MCP_ACCESS_FILE": path])
+        XCTAssertTrue(config.isAllowed(from: "+15551234567", chat: "+15551234567"))
+        XCTAssertFalse(config.isAllowed(from: "+15550000000", chat: "+15550000000"))
+    }
+
+    func testGroupAllowlistGatesOnChatIdentifier() throws {
+        let path = try writeAccessFile("""
+        {"allowFrom": ["+15551234567"], "groups": ["chat646855985291785786"]}
+        """)
+        let config = AccessConfig.load(environment: ["MACOS_MCP_ACCESS_FILE": path])
+        // Allowed group passes even from a sender not on the DM allowlist.
+        XCTAssertTrue(config.isAllowed(from: "+15550000000", chat: "chat646855985291785786"))
+        // Unknown group is blocked.
+        XCTAssertFalse(config.isAllowed(from: "+15551234567", chat: "chat999999999999999999"))
+    }
+
+    func testEmailHandleIsNotTreatedAsGroup() throws {
+        let path = try writeAccessFile(#"{"allowFrom": ["friend@example.com"]}"#)
+        let config = AccessConfig.load(environment: ["MACOS_MCP_ACCESS_FILE": path])
+        // chat_identifier starting with "chat" but non-numeric must be a DM.
+        XCTAssertTrue(config.isAllowed(from: "friend@example.com", chat: "chat@example.com"))
+    }
+
+    // MARK: - normalizePhone()
+
+    func testNormalizePhone() {
+        XCTAssertEqual(AccessConfig.normalizePhone("(555) 123-4567"), "+15551234567")
+        XCTAssertEqual(AccessConfig.normalizePhone("5551234567"), "+15551234567")
+        XCTAssertEqual(AccessConfig.normalizePhone("15551234567"), "+15551234567")
+        XCTAssertEqual(AccessConfig.normalizePhone("+445551234567"), "+445551234567")
+        XCTAssertEqual(AccessConfig.normalizePhone("Friend@Example.com"), "friend@example.com")
+    }
+
+    func testIsGroupIdentifier() {
+        XCTAssertTrue(AccessConfig.isGroupIdentifier("chat646855985291785786"))
+        XCTAssertFalse(AccessConfig.isGroupIdentifier("chat"))
+        XCTAssertFalse(AccessConfig.isGroupIdentifier("chat@example.com"))
+        XCTAssertFalse(AccessConfig.isGroupIdentifier("+15551234567"))
+    }
+}


### PR DESCRIPTION
## What

Adds a sender/group **allowlist** to the iMessage webhook poller. `AccessConfig` loads a `MACOS_MCP_OWNER_PHONE` env var plus an optional `~/.config/macos-mcp/access.json` (override path via `MACOS_MCP_ACCESS_FILE`):

```json
{
  "allowFrom": ["+15551234567", "+15559876543"],
  "groups": ["chat646855985291785786"]
}
```

Group chats match on `chat_identifier` (the `chat<digits>` form the poller reports); direct messages match the normalized sender handle (E.164 for phone numbers, lowercased for email handles).

## Behavior

- **Unconfigured -> permissive.** With no owner phone and no config file the gate stays inactive and every inbound message is forwarded, exactly as today. Operators opt in explicitly; existing deployments are unaffected.
- **Configured -> enforced.** Only allowlisted senders/groups reach the webhook. Blocked messages still advance the poll watermark, so they are never re-evaluated.

## Provenance

This is the one substantive piece of the stale `fix/agent-timeout-and-pid-guard` branch (#29) that is **not already in `main`**. That branch's headline work — MCP server mode, stdio transport, in-process SQLite poller — already landed via #27, which was extracted from it. Rebasing the whole branch would mostly re-litigate #27, so the access-control residue is extracted onto current `main` instead.

Echo suppression (`EchoTracker`) from that branch was intentionally **dropped**: `main`'s in-process poller already filters `is_from_me = 0` and never sends from inside the loop, so it had no live effect here.

## Tests

`AccessControlTests` (9 cases): fail-closed default, DM allowlist, group gating on `chat_identifier`, email-vs-group disambiguation, phone normalization, and owner-phone + file merge. Mirrors the existing `ScopedFilesCore` library+test pattern.

## Verification

- `make build` — universal binary (arm64 + x86_64) compiles clean with the new file and wiring.
- `make test-logic-docker` — 14/14 tests pass (9 new + 5 existing), 0 failures.
- Runtime probe: MCP server healthy (`initialize` + 25 tools); poller logs `Access control not configured` when unset and `Access control active` with correct phone/group counts when a config is present.

Closes out the residue of #29 — suggest closing that PR as superseded once this lands.
