### PR TITLE
Outbound allowlist: send tools gated by AccessConfig

### DIFF
--- a/Sources/AccessControl.swift
+++ b/Sources/AccessControl.swift
@@ -73,6 +73,19 @@ struct AccessConfig {
         return allowFrom.contains(AccessConfig.normalizePhone(handle))
     }
 
+    /// Outbound gate: an empty (unconfigured) config permits all recipients,
+    /// mirroring the inbound poller's permissive default. Once configured,
+    /// sends are limited to the same allowlist that gates inbound — group
+    /// identifiers match `allowedGroups`, everything else matches the
+    /// normalized handle against `allowFrom`.
+    func isAllowedRecipient(_ recipient: String) -> Bool {
+        if isEmpty { return true }
+        if AccessConfig.isGroupIdentifier(recipient) {
+            return allowedGroups.contains(recipient)
+        }
+        return allowFrom.contains(AccessConfig.normalizePhone(recipient))
+    }
+
     /// A group `chat_identifier` is the literal `chat` followed by digits
     /// (e.g. `chat646855985291785786`). Requiring the numeric suffix avoids
     /// misclassifying handles such as `chat@example.com` as groups.

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -343,6 +343,13 @@ private let mcpTools: [[String: Any]] = [
 
 private let outboundAccessConfig = AccessConfig.load()
 
+/// "owner" resolves to MACOS_MCP_OWNER_PHONE so agent callers never need the
+/// raw number in a command line (agents mask PII and break literal numbers).
+private func resolveOwnerAlias(_ contact: String) -> String {
+    guard contact.lowercased() == "owner" else { return contact }
+    return ProcessInfo.processInfo.environment["MACOS_MCP_OWNER_PHONE"] ?? contact
+}
+
 /// Non-nil = error JSON to return instead of dispatching the send.
 private func outboundDenied(_ recipient: String) -> String? {
     if outboundAccessConfig.isAllowedRecipient(recipient) { return nil }
@@ -393,14 +400,16 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
 
     switch name {
     case "send_imessage":
-        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
-        args = ["send", "message", input["contact"] as? String ?? "", input["text"] as? String ?? ""]
+        let smContact = resolveOwnerAlias(input["contact"] as? String ?? "")
+        if let denied = outboundDenied(smContact) { return denied }
+        args = ["send", "message", smContact, input["text"] as? String ?? ""]
     case "send_to_chat":
         if let denied = outboundDenied(input["chat_id"] as? String ?? "") { return denied }
         args = ["send", "chat", input["chat_id"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_file":
-        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
-        args = ["send", "file", input["contact"] as? String ?? "", input["file_path"] as? String ?? ""]
+        let sfContact = resolveOwnerAlias(input["contact"] as? String ?? "")
+        if let denied = outboundDenied(sfContact) { return denied }
+        args = ["send", "file", sfContact, input["file_path"] as? String ?? ""]
     case "download_file":
         return downloadFile(input["url"] as? String ?? "", filename: input["filename"] as? String)
     case "vault_read":

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -339,6 +339,17 @@ private let mcpTools: [[String: Any]] = [
     ],
 ]
 
+// MARK: - Outbound Access
+
+private let outboundAccessConfig = AccessConfig.load()
+
+/// Non-nil = error JSON to return instead of dispatching the send.
+private func outboundDenied(_ recipient: String) -> String? {
+    if outboundAccessConfig.isAllowedRecipient(recipient) { return nil }
+    log(.error, .mcp, "Outbound send blocked by allowlist", extra: ["recipient": recipient])
+    return "{\"error\": \"Recipient not in the allowlist. Sends are limited to the owner and ~/.config/macos-mcp/access.json entries (allowFrom/groups).\"}"
+}
+
 // MARK: - Tool Dispatch
 
 /// Integer tool parameter; JSON numbers may arrive as Int or Double.
@@ -382,10 +393,13 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
 
     switch name {
     case "send_imessage":
+        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
         args = ["send", "message", input["contact"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_to_chat":
+        if let denied = outboundDenied(input["chat_id"] as? String ?? "") { return denied }
         args = ["send", "chat", input["chat_id"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_file":
+        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
         args = ["send", "file", input["contact"] as? String ?? "", input["file_path"] as? String ?? ""]
     case "download_file":
         return downloadFile(input["url"] as? String ?? "", filename: input["filename"] as? String)


### PR DESCRIPTION
Complement to #39: the same allowlist that filters inbound senders now gates outbound sends. send_imessage / send_to_chat / send_file refuse recipients outside the configured set (owner phone + access.json allowFrom/groups) with an actionable error; an unconfigured instance stays permissive, matching the inbound default.

Verified: unlisted number and unlisted group both refused; owner send delivered; no regression in message reads.