### PR TITLE
Outbound send allowlist + owner alias + calendar update/delete tools

### DIFF
--- a/Sources/AccessControl.swift
+++ b/Sources/AccessControl.swift
@@ -73,6 +73,19 @@ struct AccessConfig {
         return allowFrom.contains(AccessConfig.normalizePhone(handle))
     }
 
+    /// Outbound gate: an empty (unconfigured) config permits all recipients,
+    /// mirroring the inbound poller's permissive default. Once configured,
+    /// sends are limited to the same allowlist that gates inbound — group
+    /// identifiers match `allowedGroups`, everything else matches the
+    /// normalized handle against `allowFrom`.
+    func isAllowedRecipient(_ recipient: String) -> Bool {
+        if isEmpty { return true }
+        if AccessConfig.isGroupIdentifier(recipient) {
+            return allowedGroups.contains(recipient)
+        }
+        return allowFrom.contains(AccessConfig.normalizePhone(recipient))
+    }
+
     /// A group `chat_identifier` is the literal `chat` followed by digits
     /// (e.g. `chat646855985291785786`). Requiring the numeric suffix avoids
     /// misclassifying handles such as `chat@example.com` as groups.

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -337,6 +337,31 @@ private let mcpTools: [[String: Any]] = [
             "required": ["calendar_id", "title", "start", "end"],
         ] as [String: Any],
     ],
+    [
+        "name": "calendar_update",
+        "description": "Update an existing calendar event",
+        "inputSchema": [
+            "type": "object",
+            "properties": [
+                "event_id": ["type": "string"],
+                "title": ["type": "string"],
+                "start": ["type": "string"],
+                "end": ["type": "string"],
+                "notes": ["type": "string"],
+                "location": ["type": "string"],
+            ],
+            "required": ["event_id"],
+        ] as [String: Any],
+    ],
+    [
+        "name": "calendar_delete",
+        "description": "Delete an existing calendar event",
+        "inputSchema": [
+            "type": "object",
+            "properties": ["event_id": ["type": "string"]],
+            "required": ["event_id"],
+        ] as [String: Any],
+    ],
 ]
 
 // MARK: - Outbound Access
@@ -480,6 +505,17 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
         if let loc = input["location"] as? String, !loc.isEmpty { args += ["--location", loc] }
         if input["all_day"] as? Bool == true { args += ["--all-day"] }
         if let avail = input["availability"] as? String, !avail.isEmpty { args += ["--availability", avail] }
+    case "calendar_update":
+        subprocessTimeout = 30
+        args = ["calendar", "update", "--id", input["event_id"] as? String ?? ""]
+        if let title = input["title"] as? String { args += ["--title", title] }
+        if let start = input["start"] as? String { args += ["--start", start] }
+        if let end = input["end"] as? String { args += ["--end", end] }
+        if let notes = input["notes"] as? String { args += ["--notes", notes] }
+        if let location = input["location"] as? String { args += ["--location", location] }
+    case "calendar_delete":
+        subprocessTimeout = 30
+        args = ["calendar", "delete", "--id", input["event_id"] as? String ?? ""]
     default:
         return "{\"error\": \"Unknown tool: \(name)\"}"
     }

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -343,6 +343,13 @@ private let mcpTools: [[String: Any]] = [
 
 private let outboundAccessConfig = AccessConfig.load()
 
+/// "owner" resolves to MACOS_MCP_OWNER_PHONE so agent callers never need the
+/// raw number in a command line (agents mask PII and break literal numbers).
+private func resolveOwnerAlias(_ contact: String) -> String {
+    guard contact.lowercased() == "owner" else { return contact }
+    return ProcessInfo.processInfo.environment["MACOS_MCP_OWNER_PHONE"] ?? contact
+}
+
 /// Non-nil = error JSON to return instead of dispatching the send.
 private func outboundDenied(_ recipient: String) -> String? {
     if outboundAccessConfig.isAllowedRecipient(recipient) { return nil }
@@ -393,14 +400,16 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
 
     switch name {
     case "send_imessage":
-        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
-        args = ["send", "message", input["contact"] as? String ?? "", input["text"] as? String ?? ""]
+        let smContact = resolveOwnerAlias(input["contact"] as? String ?? "")
+        if let denied = outboundDenied(smContact) { return denied }
+        args = ["send", "message", smContact, input["text"] as? String ?? ""]
     case "send_to_chat":
         if let denied = outboundDenied(input["chat_id"] as? String ?? "") { return denied }
         args = ["send", "chat", input["chat_id"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_file":
-        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
-        args = ["send", "file", input["contact"] as? String ?? "", input["file_path"] as? String ?? ""]
+        let sfContact = resolveOwnerAlias(input["contact"] as? String ?? "")
+        if let denied = outboundDenied(sfContact) { return denied }
+        args = ["send", "file", sfContact, input["file_path"] as? String ?? ""]
     case "download_file":
         return downloadFile(input["url"] as? String ?? "", filename: input["filename"] as? String)
     case "vault_read":

--- a/Sources/Serve.swift
+++ b/Sources/Serve.swift
@@ -339,6 +339,17 @@ private let mcpTools: [[String: Any]] = [
     ],
 ]
 
+// MARK: - Outbound Access
+
+private let outboundAccessConfig = AccessConfig.load()
+
+/// Non-nil = error JSON to return instead of dispatching the send.
+private func outboundDenied(_ recipient: String) -> String? {
+    if outboundAccessConfig.isAllowedRecipient(recipient) { return nil }
+    log(.error, .mcp, "Outbound send blocked by allowlist", extra: ["recipient": recipient])
+    return "{\"error\": \"Recipient not in the allowlist. Sends are limited to the owner and ~/.config/macos-mcp/access.json entries (allowFrom/groups).\"}"
+}
+
 // MARK: - Tool Dispatch
 
 /// Integer tool parameter; JSON numbers may arrive as Int or Double.
@@ -382,10 +393,13 @@ private func dispatchTool(_ name: String, _ input: [String: Any]) -> String {
 
     switch name {
     case "send_imessage":
+        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
         args = ["send", "message", input["contact"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_to_chat":
+        if let denied = outboundDenied(input["chat_id"] as? String ?? "") { return denied }
         args = ["send", "chat", input["chat_id"] as? String ?? "", input["text"] as? String ?? ""]
     case "send_file":
+        if let denied = outboundDenied(input["contact"] as? String ?? "") { return denied }
         args = ["send", "file", input["contact"] as? String ?? "", input["file_path"] as? String ?? ""]
     case "download_file":
         return downloadFile(input["url"] as? String ?? "", filename: input["filename"] as? String)


### PR DESCRIPTION
Captures what's currently deployed on minerva.

## Changes
- **Outbound allowlist** — `send_imessage`, `send_to_chat`, `send_file` now refuse recipients outside the configured allowlist (owner phone + `access.json` `allowFrom`/`groups`), reusing the same `AccessConfig` that gates the inbound poller. Unconfigured stays permissive; note that `MACOS_MCP_OWNER_PHONE` seeds `allowFrom`, so a deploy with the owner phone set makes the gate active (owner-only) until `access.json` lists more.
- **Owner alias** — send tools accept an owner alias rather than requiring a raw number.
- **calendar_update / calendar_delete MCP tools** — wire the existing `calendar update`/`calendar delete` CLI subcommands into the MCP tool surface, so callers can modify and remove events, not just create them.

## Verification
- `make test-logic-docker`: 14 tests, 0 failures (AccessControl allowlist logic + ScopedFiles).
- `make build`: clean universal compile.
- Calendar tools verified live end-to-end through the deployed MCP server: `calendar_list` (fullAccess), `calendar_create` -> `calendar_delete` round-trip both succeeded.